### PR TITLE
Remove role selection from email registration

### DIFF
--- a/client/src/components/Auth/UserRegistration.tsx
+++ b/client/src/components/Auth/UserRegistration.tsx
@@ -4,13 +4,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { useToast } from '@/hooks/use-toast';
 import { registerUser } from '@/lib/firebase';
 import { useAuth } from '@/hooks/useAuth';
-import { UserPlus, Eye, EyeOff, Mail, Lock, User, Shield } from 'lucide-react';
+import { UserPlus, Eye, EyeOff, Mail, Lock, User } from 'lucide-react';
 
 const registrationSchema = z.object({
   firstName: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
@@ -18,7 +17,6 @@ const registrationSchema = z.object({
   email: z.string().email('Email inválido'),
   password: z.string().min(6, 'Senha deve ter pelo menos 6 caracteres'),
   confirmPassword: z.string(),
-  role: z.enum(['admin', 'colaborador']).default('colaborador'),
 }).refine((data) => data.password === data.confirmPassword, {
   message: 'Senhas não coincidem',
   path: ['confirmPassword'],
@@ -52,7 +50,6 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
       email: '',
       password: '',
       confirmPassword: '',
-      role: 'colaborador',
     },
   });
 
@@ -67,17 +64,16 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
   const handleRegister = async (data: RegistrationData) => {
     setIsLoading(true);
     try {
-      const result = await registerUser(
+      await registerUser(
         data.email,
         data.password,
         data.firstName,
-        data.lastName,
-        data.role
+        data.lastName
       );
 
       toast({
         title: 'Usuário registrado com sucesso!',
-        description: `${data.firstName} ${data.lastName} foi adicionado como ${data.role}.`,
+        description: `${data.firstName} ${data.lastName} foi adicionado como Colaborador.`,
       });
 
       registerForm.reset();
@@ -184,31 +180,6 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
                         <Input {...field} type="email" placeholder="email@exemplo.com" className="pl-10" />
                       </div>
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={registerForm.control}
-                name="role"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Função</FormLabel>
-                    <Select onValueChange={field.onChange} defaultValue={field.value}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <div className="flex items-center space-x-2">
-                            <Shield className="h-4 w-4 text-gray-400" />
-                            <SelectValue placeholder="Selecione a função" />
-                          </div>
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="colaborador">Colaborador</SelectItem>
-                        <SelectItem value="admin">Administrador</SelectItem>
-                      </SelectContent>
-                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
## Summary
- Remove role dropdown from email registration form and default new accounts to Colaborador
- Update registration schema and success message accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a774040d083229b6eb8235a65678d