### PR TITLE
fix: allow email input when registering

### DIFF
--- a/client/src/components/Auth/UserRegistration.tsx
+++ b/client/src/components/Auth/UserRegistration.tsx
@@ -174,9 +174,9 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Email</FormLabel>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                      <FormControl>
+                    <FormControl>
+                      <div className="relative">
+                        <Mail className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-gray-400" />
                         <Input
                           type="email"
                           placeholder="email@exemplo.com"
@@ -184,8 +184,8 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
                           autoComplete="email"
                           {...field}
                         />
-                      </FormControl>
-                    </div>
+                      </div>
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -263,9 +263,9 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Email</FormLabel>
-                    <div className="relative">
-                      <Mail className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                      <FormControl>
+                    <FormControl>
+                      <div className="relative">
+                        <Mail className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-gray-400" />
                         <Input
                           type="email"
                           placeholder="email@exemplo.com"
@@ -273,8 +273,8 @@ export default function UserRegistration({ onClose }: UserRegistrationProps) {
                           autoComplete="email"
                           {...field}
                         />
-                      </FormControl>
-                    </div>
+                      </div>
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}


### PR DESCRIPTION
## Summary
- ensure registration email field accepts input
- align login and registration email fields for consistency

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (modules transformed)
- `npm run check` (fails: TS2322 type errors)


------
https://chatgpt.com/codex/tasks/task_e_689a7eac77dc8322b13153213dd22a64