### PR TITLE
Handle 'none' assignee selection in task modal

### DIFF
--- a/client/src/components/Kanban/TaskModal.tsx
+++ b/client/src/components/Kanban/TaskModal.tsx
@@ -140,7 +140,11 @@ export default function TaskModal({ isOpen, onClose, projects }: TaskModalProps)
   });
 
   const onSubmit = (data: TaskFormData) => {
-    createTaskMutation.mutate(data);
+    const formattedData = {
+      ...data,
+      assigneeId: data.assigneeId === 'none' ? undefined : data.assigneeId,
+    };
+    createTaskMutation.mutate(formattedData);
   };
 
   const handleClose = () => {
@@ -222,9 +226,9 @@ export default function TaskModal({ isOpen, onClose, projects }: TaskModalProps)
                     </FormControl>
                     <SelectContent>
                       {activeProjects.length === 0 ? (
-                        <SelectItem value="" disabled>
+                        <div className="p-2 text-muted-foreground">
                           Nenhum projeto ativo encontrado
-                        </SelectItem>
+                        </div>
                       ) : (
                         activeProjects.map((project) => (
                           <SelectItem key={project.id} value={project.id}>
@@ -382,7 +386,7 @@ export default function TaskModal({ isOpen, onClose, projects }: TaskModalProps)
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value="">Não atribuída</SelectItem>
+                        <SelectItem value="none">Não atribuída</SelectItem>
                         {users.map((user) => (
                           <SelectItem key={user.id} value={user.id}>
                             {getUserDisplayName(user)}

--- a/client/src/services/firebaseService.ts
+++ b/client/src/services/firebaseService.ts
@@ -563,7 +563,11 @@ export const firebaseService = {
   },
 
   async createTask(taskData: any) {
-    return await taskService.addTask(taskData);
+    const data = { ...taskData };
+    if (!data.assigneeId || data.assigneeId === 'none') {
+      delete data.assigneeId;
+    }
+    return await taskService.addTask(data);
   },
 
   async updateTask(id: string, data: any) {


### PR DESCRIPTION
## Summary
- improve project dropdown when no active projects
- allow "Não atribuída" option with value `none` and convert to undefined on submit
- ignore empty assignee when creating tasks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Type '{ id: number; title: string; description: string | null; status: "aberta" | ... }' is not assignable to type 'TaskWithDetails')*


------
https://chatgpt.com/codex/tasks/task_e_68ad000c76808322a6e0f4eeea3668bb