### PR TITLE
feat: extend task model for advanced project management

### DIFF
--- a/client/src/services/firebaseService.ts
+++ b/client/src/services/firebaseService.ts
@@ -763,7 +763,7 @@ export const firebaseService = {
         .slice(-6); // Last 6 months
 
       // Get recent activities from tasks and projects
-      const recentActivities = [];
+      const recentActivities: Array<{ id: string; type: string; description: string; timestamp: Date; user: string }> = [];
       
       // Recent task updates
       const recentTasks = allTasksSnapshot.docs
@@ -786,8 +786,8 @@ export const firebaseService = {
       });
 
       // Recent project updates
-      const recentProjects = allProjectsSnapshot.docs
-        .map(doc => ({ id: doc.id, ...doc.data() }))
+      const recentProjects: any[] = allProjectsSnapshot.docs
+        .map(doc => ({ id: doc.id, ...(doc.data() as any) }))
         .sort((a, b) => {
           const dateA = a.updatedAt?.toDate ? a.updatedAt.toDate() : new Date(a.updatedAt);
           const dateB = b.updatedAt?.toDate ? b.updatedAt.toDate() : new Date(b.updatedAt);
@@ -795,7 +795,7 @@ export const firebaseService = {
         })
         .slice(0, 2);
 
-      recentProjects.forEach(project => {
+      recentProjects.forEach((project: any) => {
         recentActivities.push({
           id: `project-${project.id}`,
           type: 'project_updated',

--- a/client/src/shared/schema.ts
+++ b/client/src/shared/schema.ts
@@ -1,7 +1,41 @@
 // Minimal shared types to support the client without the Replit DB server
 
 export type TaskStatus = 'aberta' | 'em_andamento' | 'concluida' | 'cancelada';
-export type TaskPriority = 'baixa' | 'media' | 'alta' | 'critica';
+export type TaskPriority = 'baixa' | 'media' | 'alta' | 'critica' | 'urgente';
+
+export interface Subtask {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority?: TaskPriority;
+  assignedUserIds?: string[];
+  dueDate?: Date | string | null;
+}
+
+export interface ChecklistItem {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+
+export interface Checklist {
+  id: string;
+  title: string;
+  items: ChecklistItem[];
+}
+
+export interface TaskRelationship {
+  id: string;
+  type: 'blocks' | 'blocked_by' | 'relates_to';
+  taskId: string;
+}
+
+export interface CustomField {
+  id: string;
+  name: string;
+  type: 'text' | 'number' | 'list' | 'date' | 'boolean';
+  value: string | number | boolean | null;
+}
 
 export interface User {
   id: string;
@@ -28,6 +62,7 @@ export interface Project {
   clientEmail?: string | null;
   clientPhone?: string | null;
   budget?: number | null;
+  estimatedHours?: number | null;
   startDate?: Date | string | null;
   endDate?: Date | string | null;
   location?: string | null;
@@ -43,17 +78,26 @@ export interface Task {
   status: TaskStatus;
   priority: TaskPriority;
   projectId: string | null;
-  assignedUserId?: string | null;
+  assignedUserId?: string | null; // legacy single responsible
+  assignedUserIds?: string[]; // multiple responsáveis
+  startDate?: Date | string | null;
   dueDate?: Date | string | null;
+  tags?: string[];
+  relationships?: TaskRelationship[];
+  customFields?: CustomField[];
+  subtasks?: Subtask[];
+  checklists?: Checklist[];
   estimatedHours?: number | null;
   actualHours?: number | null;
   createdAt?: Date | null;
   updatedAt?: Date | null;
+  completedAt?: Date | string | null;
 }
 
 export interface TaskWithDetails extends Task {
   project?: Project | null;
   assignedUser?: User | null;
+  assignedUsers?: User[];
   timeEntries?: Array<{ id: string; startedAt: Date; endedAt?: Date | null; hours?: number | null }>;
 }
 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,14 +1,34 @@
-export type { 
-  User, 
-  Task, 
-  Project, 
-  TaskWithDetails, 
-  ProjectWithTasks, 
-  UserWithStats,
+import type {
+  User,
+  Task,
+  Project,
+  TaskWithDetails,
+  ProjectWithTasks,
   File,
   Notification,
   TimeEntry,
+  Subtask,
+  Checklist,
+  ChecklistItem,
+  TaskRelationship,
+  CustomField,
 } from "@shared/schema";
+
+export type {
+  User,
+  Task,
+  Project,
+  TaskWithDetails,
+  ProjectWithTasks,
+  File,
+  Notification,
+  TimeEntry,
+  Subtask,
+  Checklist,
+  ChecklistItem,
+  TaskRelationship,
+  CustomField,
+};
 
 export interface DashboardStats {
   totalTasks: number;

--- a/client/src/utils/pdfGenerator.ts
+++ b/client/src/utils/pdfGenerator.ts
@@ -100,13 +100,13 @@ export class PDFReportGenerator {
     return priorityMap[priority] || priority;
   }
 
-  private formatDate(date: Date | string | null): string {
+  private formatDate(date?: Date | string | null): string {
     if (!date) return 'Não definido';
     const dateObj = typeof date === 'string' ? new Date(date) : date;
     return format(dateObj, 'dd/MM/yyyy', { locale: ptBR });
   }
 
-  private formatDateTime(date: Date | string | null): string {
+  private formatDateTime(date?: Date | string | null): string {
     if (!date) return 'Não definido';
     const dateObj = typeof date === 'string' ? new Date(date) : date;
     return format(dateObj, 'dd/MM/yyyy HH:mm', { locale: ptBR });


### PR DESCRIPTION
## Summary
- add advanced task metadata including subtasks, checklists, relationships, custom fields, tags and multi-user assignment
- expose new schema types and project estimated hours to client types
- improve PDF generation and dashboard helpers for optional dates and recent activity typing

## Testing
- `npm run check` *(fails: Property 'orderByDueDate' does not exist on type '{}', among others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c8df84d48322a9ef58bb483a2ae1