### PR TITLE
fix: handle array tags when updating tasks

### DIFF
--- a/client/src/components/Kanban/TaskModal.tsx
+++ b/client/src/components/Kanban/TaskModal.tsx
@@ -238,7 +238,11 @@ export default function TaskModal({ isOpen, onClose, projects, task }: TaskModal
         startDate: taskData.startDate,
         dueDate: taskData.dueDate,
         assignedUserIds: taskData.assignedUserIds || [],
-        tags: taskData.tags ? taskData.tags.split(',').map(t => t.trim()).filter(Boolean) : [],
+        tags: Array.isArray(taskData.tags)
+          ? taskData.tags
+          : taskData.tags
+          ? taskData.tags.split(',').map(t => t.trim()).filter(Boolean)
+          : [],
         subtasks: taskData.subtasks?.map(st => ({
           ...st,
           assignedUserIds:


### PR DESCRIPTION
## Summary
- avoid calling `split` on array tags during task updates

## Testing
- `npm test` (fails: Missing script)
- `npm run check` (fails: TypeScript errors)

------
https://chatgpt.com/codex/tasks/task_e_68c0d90ad78083228cdf8a87d3136dfe