### PR TITLE
Ajusta aparência de tarefas canceladas no Kanban

### DIFF
--- a/client/src/components/Kanban/KanbanBoard.tsx
+++ b/client/src/components/Kanban/KanbanBoard.tsx
@@ -342,11 +342,17 @@ export default function KanbanBoard() {
                                   snapshot.isDragging
                                     ? 'rotate-2 shadow-lg ring-2 ring-blue-400'
                                     : 'hover:shadow-md'
-                                }`}
+                                } ${task.status === 'cancelada' ? 'opacity-60' : ''}`}
                               >
                                 <CardHeader className="pb-2">
                                   <div className="flex items-start justify-between">
-                                    <CardTitle className="text-sm font-medium line-clamp-2">
+                                    <CardTitle
+                                      className={`text-sm font-medium line-clamp-2 ${
+                                        task.status === 'cancelada'
+                                          ? 'line-through text-gray-500 dark:text-gray-400'
+                                          : ''
+                                      }`}
+                                    >
                                       {task.title}
                                     </CardTitle>
                                     <div className="flex items-center gap-1 ml-2">

--- a/client/src/components/Kanban/TaskCard.tsx
+++ b/client/src/components/Kanban/TaskCard.tsx
@@ -27,6 +27,7 @@ const PRIORITY_LABELS = {
 
 export default function TaskCard({ task, onDragStart }: TaskCardProps) {
   const { user } = useAuth();
+  const isCanceled = task.status === 'cancelada';
   
   const getUserDisplayName = () => {
     if (task.assignedUser?.firstName && task.assignedUser?.lastName) {
@@ -72,7 +73,7 @@ export default function TaskCard({ task, onDragStart }: TaskCardProps) {
     <div
       draggable
       onDragStart={(e) => onDragStart(e, task.id)}
-      className="bg-white dark:bg-gray-700 rounded-lg p-3 sm:p-4 shadow-sm border border-gray-100 dark:border-gray-600 cursor-move hover:shadow-md transition-shadow group"
+      className={`bg-white dark:bg-gray-700 rounded-lg p-3 sm:p-4 shadow-sm border border-gray-100 dark:border-gray-600 cursor-move hover:shadow-md transition-shadow group ${isCanceled ? 'opacity-60' : ''}`}
     >
       {/* Priority and Drag Handle */}
       <div className="flex items-center justify-between mb-2">
@@ -86,7 +87,13 @@ export default function TaskCard({ task, onDragStart }: TaskCardProps) {
       </div>
 
       {/* Task Title */}
-      <h4 className="font-semibold mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors text-sm sm:text-base">
+      <h4
+        className={`font-semibold mb-2 line-clamp-2 transition-colors text-sm sm:text-base ${
+          isCanceled
+            ? 'line-through text-gray-500 dark:text-gray-400'
+            : 'group-hover:text-blue-600'
+        }`}
+      >
         {task.title}
       </h4>
 

--- a/client/src/components/Kanban/TaskCardSimple.tsx
+++ b/client/src/components/Kanban/TaskCardSimple.tsx
@@ -29,6 +29,7 @@ const PRIORITY_LABELS = {
 export default function TaskCardSimple({ task, onDragStart }: TaskCardProps) {
   const { user } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const isCanceled = task.status === 'cancelada';
   
   const getUserDisplayName = () => {
     if (task.assignedUser?.firstName && task.assignedUser?.lastName) {
@@ -82,7 +83,7 @@ export default function TaskCardSimple({ task, onDragStart }: TaskCardProps) {
         draggable
         onDragStart={(e) => onDragStart(e, task.id.toString())}
         onClick={handleCardClick}
-        className="bg-white dark:bg-gray-700 rounded-lg p-3 sm:p-4 shadow-sm border border-gray-100 dark:border-gray-600 cursor-grab hover:cursor-grab hover:shadow-md transition-all duration-200 group"
+        className={`bg-white dark:bg-gray-700 rounded-lg p-3 sm:p-4 shadow-sm border border-gray-100 dark:border-gray-600 cursor-grab hover:cursor-grab hover:shadow-md transition-all duration-200 group ${isCanceled ? 'opacity-60' : ''}`}
       >
         {/* Priority and Drag Handle */}
         <div className="flex items-center justify-between mb-2">
@@ -96,7 +97,13 @@ export default function TaskCardSimple({ task, onDragStart }: TaskCardProps) {
         </div>
 
         {/* Task Title */}
-        <h4 className="font-semibold mb-2 line-clamp-2 group-hover:text-blue-600 transition-colors text-sm sm:text-base">
+        <h4
+          className={`font-semibold mb-2 line-clamp-2 transition-colors text-sm sm:text-base ${
+            isCanceled
+              ? 'line-through text-gray-500 dark:text-gray-400'
+              : 'group-hover:text-blue-600'
+          }`}
+        >
           {task.title}
         </h4>
 


### PR DESCRIPTION
## Summary
- reduz a opacidade dos cards de tarefas com status cancelada em todas as variações do Kanban
- aplica efeito de texto tachado aos títulos de tarefas canceladas para sinalizar o estado

## Testing
- `npm run check` *(falha: o projeto já possuía diversos erros de TypeScript não relacionados a esta alteração)*

------
https://chatgpt.com/codex/tasks/task_e_68d341c97cb0832294d1cda94dcdf17a