### PR TITLE
Fix Kanban task tag persistence on status changes

### DIFF
--- a/client/src/services/firebaseService.ts
+++ b/client/src/services/firebaseService.ts
@@ -646,7 +646,9 @@ export const firebaseService = {
       }
       delete payload.assignedUserId;
     }
-    payload.tags = normalizeTaskTags(payload.tags);
+    if (payload.tags !== undefined) {
+      payload.tags = normalizeTaskTags(payload.tags);
+    }
     return await taskService.updateTask(id, payload);
   },
 


### PR DESCRIPTION
## Summary
- avoid clearing task tags when updating a task through the Firebase service
- normalize tags only when the update payload explicitly includes tag changes

## Testing
- npm run check *(fails: pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0d1497608322a48bfc9cc41cd970