### PR TITLE
Fix select items without placeholder value

### DIFF
--- a/client/src/components/Kanban/TaskDetailsDrawer.tsx
+++ b/client/src/components/Kanban/TaskDetailsDrawer.tsx
@@ -422,12 +422,15 @@ export function TaskDetailsDrawer({
                 <section className="grid gap-4 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5 md:grid-cols-2">
                   <div>
                     <Label className="text-xs uppercase text-slate-400">Projeto</Label>
-                    <Select value={projectId} onValueChange={setProjectId}>
+                    <Select
+                      value={projectId === "" ? "none" : projectId}
+                      onValueChange={(value) => setProjectId(value === "none" ? "" : value)}
+                    >
                       <SelectTrigger className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100">
                         <SelectValue placeholder="Selecione um projeto" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">Sem projeto</SelectItem>
+                        <SelectItem value="none">Sem projeto</SelectItem>
                         {projects.map((project) => (
                           <SelectItem key={project.id} value={project.id}>
                             {project.name}

--- a/client/src/components/Projects/ProjectManagement.tsx
+++ b/client/src/components/Projects/ProjectManagement.tsx
@@ -767,14 +767,16 @@ function ProjectDetailsDrawer({ open, onOpenChange, project }: ProjectDetailsDra
                   <div className="space-y-3">
                     <Label className="text-xs uppercase text-slate-400">Responsável</Label>
                     <Select
-                      value={formState.managerUserId}
-                      onValueChange={(value) => setFormState(prev => ({ ...prev, managerUserId: value }))}
+                      value={formState.managerUserId ? formState.managerUserId : "none"}
+                      onValueChange={(value) =>
+                        setFormState(prev => ({ ...prev, managerUserId: value === "none" ? "" : value }))
+                      }
                     >
                       <SelectTrigger className="border-slate-800 bg-slate-900/60 text-slate-100">
                         <SelectValue placeholder="Selecione o responsável" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">Não definido</SelectItem>
+                        <SelectItem value="none">Não definido</SelectItem>
                         {users.map(user => (
                           <SelectItem key={user.id} value={user.id}>
                             {user.firstName || user.lastName


### PR DESCRIPTION
## Summary
- prevent the kanban task project selector from using empty-string option values that break Radix Select
- update project management responsible selector to map the "no selection" state to a sentinel value instead of an empty string

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df1888cb60832281ab2fb8bbb1d268