### PR TITLE
Align Kanban task drawer palette

### DIFF
--- a/client/src/components/Kanban/TaskDetailsDrawer.tsx
+++ b/client/src/components/Kanban/TaskDetailsDrawer.tsx
@@ -206,13 +206,13 @@ export function TaskDetailsDrawer({
   const statusColor = useMemo(() => {
     switch (status) {
       case "concluida":
-        return "bg-emerald-500/20 text-emerald-300 border border-emerald-500/40";
+        return "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-200";
       case "em_andamento":
-        return "bg-blue-500/20 text-blue-300 border border-blue-500/40";
+        return "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-200";
       case "cancelada":
-        return "bg-red-500/20 text-red-300 border border-red-500/40";
+        return "border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200";
       default:
-        return "bg-slate-700/60 text-slate-200 border border-slate-600";
+        return "border-muted bg-muted/60 text-foreground";
     }
   }, [status]);
 
@@ -223,13 +223,13 @@ export function TaskDetailsDrawer({
           side="right"
           className="w-full sm:max-w-xl lg:max-w-3xl p-0 overflow-hidden"
         >
-          <div className="flex h-full flex-col bg-slate-950 text-slate-100">
-            <div className="border-b border-slate-800 px-6 py-6">
+          <div className="flex h-full flex-col bg-background text-foreground">
+            <div className="border-b border-border px-6 py-6">
               <SheetHeader className="space-y-3">
-                <SheetTitle className="text-xl font-semibold text-white">
+                <SheetTitle className="text-xl font-semibold">
                   {title || task.title || "Detalhes da tarefa"}
                 </SheetTitle>
-                <SheetDescription className="text-slate-400">
+                <SheetDescription className="text-sm text-muted-foreground">
                   Gerencie os principais detalhes da tarefa selecionada.
                 </SheetDescription>
               </SheetHeader>
@@ -237,12 +237,8 @@ export function TaskDetailsDrawer({
               <div className="mt-4 flex flex-wrap items-center gap-3">
                 <Button
                   size="sm"
-                  className={cn(
-                    "rounded-full px-4",
-                    status === "concluida"
-                      ? "bg-slate-800 text-slate-200 hover:bg-slate-700"
-                      : "bg-emerald-500 text-white hover:bg-emerald-600"
-                  )}
+                  variant={status === "concluida" ? "outline" : "default"}
+                  className="rounded-full px-4"
                   onClick={handleMarkAsCompleted}
                   type="button"
                   disabled={updateTaskMutation.isPending}
@@ -255,13 +251,16 @@ export function TaskDetailsDrawer({
                   {STATUS_LABELS[status] || status}
                 </Badge>
 
-                <Badge variant="outline" className="rounded-full px-3 py-1 text-xs text-amber-300 border-amber-500/40">
+                <Badge
+                  variant="outline"
+                  className="rounded-full px-3 py-1 text-xs border-amber-200/60 text-amber-700 dark:border-amber-700/60 dark:text-amber-300"
+                >
                   Prioridade: {PRIORITY_LABELS[priority] || priority}
                 </Badge>
 
                 {dueDate && (
-                  <span className="flex items-center rounded-full bg-slate-800/80 px-3 py-1 text-xs text-slate-300">
-                    <CalendarIcon className="mr-2 h-3.5 w-3.5" />
+                  <span className="flex items-center rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
+                    <CalendarIcon className="mr-2 h-3.5 w-3.5 text-primary" />
                     Vencimento em {format(new Date(dueDate), "dd 'de' MMMM", { locale: ptBR })}
                   </span>
                 )}
@@ -272,34 +271,34 @@ export function TaskDetailsDrawer({
               <div className="flex flex-col gap-8 px-6 py-6">
                 <section className="space-y-4">
                   <div>
-                    <Label className="text-xs uppercase text-slate-400">Título</Label>
+                    <Label className="text-xs font-medium uppercase text-muted-foreground">Título</Label>
                     <Input
                       value={title}
                       onChange={(event) => setTitle(event.target.value)}
                       placeholder="Dê um título claro à tarefa"
-                      className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100 placeholder:text-slate-500"
+                      className="mt-1"
                     />
                   </div>
 
                   <div>
-                    <Label className="text-xs uppercase text-slate-400">Descrição</Label>
+                    <Label className="text-xs font-medium uppercase text-muted-foreground">Descrição</Label>
                     <Textarea
                       value={description}
                       onChange={(event) => setDescription(event.target.value)}
                       placeholder="Adicione detalhes importantes, links e anexos relevantes."
                       rows={4}
-                      className="mt-1 resize-none border-slate-800 bg-slate-900/60 text-slate-100 placeholder:text-slate-500"
+                      className="mt-1 resize-none"
                     />
                   </div>
                 </section>
 
-                <section className="space-y-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5">
+                <section className="space-y-3 rounded-xl border border-border bg-card p-5">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-semibold text-white">Responsáveis & Status</h3>
+                    <h3 className="text-sm font-semibold">Responsáveis & Status</h3>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="text-slate-300 hover:bg-slate-800"
+                      className="rounded-full text-muted-foreground"
                       type="button"
                       onClick={() => task && onOpenAdvancedEdit?.(task)}
                     >
@@ -310,14 +309,14 @@ export function TaskDetailsDrawer({
 
                   <div className="grid gap-4 md:grid-cols-2">
                     <div className="space-y-2">
-                      <Label className="text-xs uppercase text-slate-400">Responsáveis</Label>
+                      <Label className="text-xs font-medium uppercase text-muted-foreground">Responsáveis</Label>
                       <div className="flex items-center gap-2">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button
                               variant="outline"
                               size="sm"
-                              className="border-slate-700 bg-slate-900/50 text-slate-200 hover:bg-slate-800"
+                              className="rounded-full"
                               type="button"
                             >
                               <UserRound className="mr-2 h-4 w-4" />
@@ -351,7 +350,7 @@ export function TaskDetailsDrawer({
                                   ? `${user.firstName} ${user.lastName}`
                                   : user.email;
                               return (
-                                <Avatar key={user.id} className="h-8 w-8 border-2 border-slate-900">
+                                <Avatar key={user.id} className="h-8 w-8 border-2 border-background">
                                   <AvatarImage
                                     src={
                                       user.profileImageUrl ||
@@ -359,7 +358,7 @@ export function TaskDetailsDrawer({
                                     }
                                     alt={displayName}
                                   />
-                                  <AvatarFallback className="bg-indigo-600 text-xs text-white">
+                                  <AvatarFallback className="bg-primary text-xs text-primary-foreground">
                                     {displayName
                                       .split(" ")
                                       .map((part) => part[0])
@@ -371,7 +370,7 @@ export function TaskDetailsDrawer({
                               );
                             })
                           ) : (
-                            <span className="rounded-full bg-slate-800 px-3 py-1 text-xs text-slate-400">
+                            <span className="rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
                               Nenhum responsável
                             </span>
                           )}
@@ -381,12 +380,12 @@ export function TaskDetailsDrawer({
 
                     <div className="grid gap-3">
                       <div>
-                        <Label className="text-xs uppercase text-slate-400">Status</Label>
+                        <Label className="text-xs font-medium uppercase text-muted-foreground">Status</Label>
                         <Select
                           value={status}
                           onValueChange={(value: Task["status"]) => setStatus(value)}
                         >
-                          <SelectTrigger className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100">
+                          <SelectTrigger className="mt-1">
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -399,12 +398,12 @@ export function TaskDetailsDrawer({
                       </div>
 
                       <div>
-                        <Label className="text-xs uppercase text-slate-400">Prioridade</Label>
+                        <Label className="text-xs font-medium uppercase text-muted-foreground">Prioridade</Label>
                         <Select
                           value={priority}
                           onValueChange={(value: Task["priority"]) => setPriority(value)}
                         >
-                          <SelectTrigger className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100">
+                          <SelectTrigger className="mt-1">
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -419,14 +418,14 @@ export function TaskDetailsDrawer({
                   </div>
                 </section>
 
-                <section className="grid gap-4 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5 md:grid-cols-2">
+                <section className="grid gap-4 rounded-xl border border-border bg-card p-5 md:grid-cols-2">
                   <div>
-                    <Label className="text-xs uppercase text-slate-400">Projeto</Label>
+                    <Label className="text-xs font-medium uppercase text-muted-foreground">Projeto</Label>
                     <Select
                       value={projectId === "" ? "none" : projectId}
                       onValueChange={(value) => setProjectId(value === "none" ? "" : value)}
                     >
-                      <SelectTrigger className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100">
+                      <SelectTrigger className="mt-1">
                         <SelectValue placeholder="Selecione um projeto" />
                       </SelectTrigger>
                       <SelectContent>
@@ -438,38 +437,38 @@ export function TaskDetailsDrawer({
                         ))}
                       </SelectContent>
                     </Select>
-                    <p className="mt-2 flex items-center text-xs text-slate-400">
-                      <ListChecks className="mr-2 h-4 w-4 text-indigo-400" />
+                    <p className="mt-2 flex items-center text-xs text-muted-foreground">
+                      <ListChecks className="mr-2 h-4 w-4 text-primary" />
                       {activeProjectName}
                     </p>
                   </div>
 
                   <div className="grid gap-4 sm:grid-cols-2">
                     <div>
-                      <Label className="text-xs uppercase text-slate-400">Início</Label>
+                      <Label className="text-xs font-medium uppercase text-muted-foreground">Início</Label>
                       <Input
                         type="date"
                         value={startDate}
                         onChange={(event) => setStartDate(event.target.value)}
-                        className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100"
+                        className="mt-1"
                       />
                     </div>
                     <div>
-                      <Label className="text-xs uppercase text-slate-400">Vencimento</Label>
+                      <Label className="text-xs font-medium uppercase text-muted-foreground">Vencimento</Label>
                       <Input
                         type="date"
                         value={dueDate}
                         onChange={(event) => setDueDate(event.target.value)}
-                        className="mt-1 border-slate-800 bg-slate-900/60 text-slate-100"
+                        className="mt-1"
                       />
                     </div>
                   </div>
                 </section>
 
                 {(task.tags && task.tags.length > 0) && (
-                  <section className="space-y-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5">
-                    <div className="flex items-center gap-2 text-sm font-semibold text-white">
-                      <TagIcon className="h-4 w-4 text-indigo-400" />
+                  <section className="space-y-3 rounded-xl border border-border bg-card p-5">
+                    <div className="flex items-center gap-2 text-sm font-semibold">
+                      <TagIcon className="h-4 w-4 text-primary" />
                       Etiquetas
                     </div>
                     <div className="flex flex-wrap gap-2">
@@ -491,9 +490,9 @@ export function TaskDetailsDrawer({
                   </section>
                 )}
 
-                <section className="space-y-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-5">
-                  <h3 className="text-sm font-semibold text-white">Comentários rápidos</h3>
-                  <p className="text-xs text-slate-400">
+                <section className="space-y-3 rounded-xl border border-border bg-card p-5">
+                  <h3 className="text-sm font-semibold">Comentários rápidos</h3>
+                  <p className="text-xs text-muted-foreground">
                     Registre alinhamentos ou decisões importantes. Os comentários são salvos localmente por enquanto.
                   </p>
                   <Textarea
@@ -501,10 +500,9 @@ export function TaskDetailsDrawer({
                     onChange={(event) => setCommentText(event.target.value)}
                     placeholder="Escreva um comentário ou atualize o andamento da tarefa..."
                     rows={3}
-                    className="border-slate-800 bg-slate-900/60 text-slate-100 placeholder:text-slate-500"
                   />
                   <div className="flex items-center justify-between">
-                    <Button type="button" size="sm" onClick={handleAddComment} className="bg-indigo-600 text-white hover:bg-indigo-500">
+                    <Button type="button" size="sm" onClick={handleAddComment}>
                       Adicionar comentário
                     </Button>
                     {onDelete && (
@@ -512,7 +510,6 @@ export function TaskDetailsDrawer({
                         type="button"
                         variant="destructive"
                         size="icon"
-                        className="bg-red-600 hover:bg-red-700"
                         onClick={() => task && onDelete(task)}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -522,13 +519,13 @@ export function TaskDetailsDrawer({
 
                   <div className="space-y-3">
                     {localComments.length === 0 ? (
-                      <p className="rounded-lg border border-dashed border-slate-800/70 px-4 py-6 text-center text-xs text-slate-500">
+                      <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-xs text-muted-foreground">
                         Nenhum comentário adicionado ainda.
                       </p>
                     ) : (
                       localComments.map((comment) => (
-                        <div key={comment.id} className="rounded-xl border border-slate-800/60 bg-slate-900/70 p-3 text-sm text-slate-200">
-                          <div className="mb-1 flex items-center justify-between text-xs text-slate-400">
+                        <div key={comment.id} className="rounded-xl border border-border bg-muted/60 p-3 text-sm text-foreground">
+                          <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
                             <span>Você</span>
                             <span>{format(comment.createdAt, "dd/MM/yyyy HH:mm")}</span>
                           </div>
@@ -540,16 +537,16 @@ export function TaskDetailsDrawer({
                 </section>
               </div>
 
-              <div className="border-t border-slate-800 bg-slate-950/90 px-6 py-4">
+              <div className="border-t border-border bg-muted/30 px-6 py-4">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <p className="text-xs text-slate-500">
+                  <p className="text-xs text-muted-foreground">
                     As alterações são sincronizadas automaticamente com o projeto vinculado.
                   </p>
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <Button
                       type="button"
                       variant="ghost"
-                      className="text-slate-300 hover:bg-slate-800"
+                      className="text-muted-foreground"
                       onClick={() => onOpenChange(false)}
                       disabled={updateTaskMutation.isPending}
                     >
@@ -558,7 +555,6 @@ export function TaskDetailsDrawer({
                     <Button
                       type="submit"
                       disabled={updateTaskMutation.isPending}
-                      className="bg-indigo-600 text-white hover:bg-indigo-500"
                     >
                       {updateTaskMutation.isPending ? "Salvando..." : "Salvar alterações"}
                     </Button>


### PR DESCRIPTION
## Summary
- restyle the Kanban task details drawer to use the global background, border, and typography tokens
- update interactive elements to rely on design system variants instead of hardcoded slate colors
- refresh status, priority, and metadata chips to use theme-aware color accents

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68df24d608b883228165ba03c6e6a851