### PR TITLE
Move task creation and editing into drawer

### DIFF
--- a/client/src/components/Kanban/TaskDetailsDrawer.tsx
+++ b/client/src/components/Kanban/TaskDetailsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -32,26 +32,27 @@ import {
 import {
   Calendar as CalendarIcon,
   CheckCircle2,
-  Edit,
   ListChecks,
   Tag as TagIcon,
   Trash2,
   UserRound,
+  Plus,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { firebaseService } from "@/services/firebaseService";
 import type { Project, Task, TaskTag, User } from "@/types";
-import { DEFAULT_TAG_COLOR, getTagTextColor } from "@/utils/tags";
+import { DEFAULT_TAG_COLOR, getTagTextColor, generateTagId, normalizeTaskTags } from "@/utils/tags";
 import { cn } from "@/lib/utils";
 
 interface TaskDetailsDrawerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   task: Task | null;
+  mode?: "create" | "edit";
   projects: Project[];
   users: User[];
   onDelete?: (task: Task) => void;
-  onOpenAdvancedEdit?: (task: Task) => void;
+  defaultProjectId?: string;
 }
 
 const PRIORITY_LABELS: Record<string, string> = {
@@ -68,14 +69,39 @@ const STATUS_LABELS: Record<string, string> = {
   cancelada: "Cancelada",
 };
 
+type TaskFormState = {
+  title: string;
+  description: string;
+  status: Task["status"];
+  priority: Task["priority"];
+  projectId: string;
+  startDate: string;
+  dueDate: string;
+  assignedUserIds: string[];
+  tags: TaskTag[];
+};
+
+type TaskMutationPayload = {
+  title: string;
+  description: string | null;
+  status: Task["status"];
+  priority: Task["priority"];
+  projectId: string | null;
+  startDate: Date | null;
+  dueDate: Date | null;
+  assignedUserIds: string[];
+  tags: TaskTag[];
+};
+
 export function TaskDetailsDrawer({
   open,
   onOpenChange,
   task,
+  mode,
   projects,
   users,
   onDelete,
-  onOpenAdvancedEdit,
+  defaultProjectId,
 }: TaskDetailsDrawerProps) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -90,49 +116,133 @@ export function TaskDetailsDrawer({
   const [assignedUserIds, setAssignedUserIds] = useState<string[]>([]);
   const [commentText, setCommentText] = useState("");
   const [localComments, setLocalComments] = useState<{ id: string; text: string; createdAt: Date }[]>([]);
+  const [tags, setTags] = useState<TaskTag[]>([]);
+
+  const computedMode: "create" | "edit" = mode ?? (task ? "edit" : "create");
+  const isCreateMode = computedMode === "create";
+  const isEditMode = computedMode === "edit" && !!task;
+
+  const resetForm = useCallback(() => {
+    setTitle("");
+    setDescription("");
+    setStatus("aberta");
+    setPriority("media");
+    setProjectId(defaultProjectId ?? "");
+    setStartDate("");
+    setDueDate("");
+    setAssignedUserIds([]);
+    setTags([]);
+    setLocalComments([]);
+    setCommentText("");
+  }, [defaultProjectId]);
 
   useEffect(() => {
-    if (!task || !open) {
+    if (!open) {
       return;
     }
 
-    setTitle(task.title || "");
-    setDescription(task.description || "");
-    setStatus((task.status as Task["status"]) || "aberta");
-    setPriority((task.priority as Task["priority"]) || "media");
-    setProjectId(task.projectId || "");
-    setStartDate(task.startDate ? format(new Date(task.startDate), "yyyy-MM-dd") : "");
-    setDueDate(task.dueDate ? format(new Date(task.dueDate), "yyyy-MM-dd") : "");
+    if (isEditMode && task) {
+      setTitle(task.title || "");
+      setDescription((task.description as string) || "");
+      setStatus((task.status as Task["status"]) || "aberta");
+      setPriority((task.priority as Task["priority"]) || "media");
+      setProjectId(task.projectId || "");
+      setStartDate(task.startDate ? format(new Date(task.startDate), "yyyy-MM-dd") : "");
+      setDueDate(task.dueDate ? format(new Date(task.dueDate), "yyyy-MM-dd") : "");
 
-    if (task.assignedUserIds && task.assignedUserIds.length > 0) {
-      setAssignedUserIds(task.assignedUserIds);
-    } else if ((task as any).assigneeId) {
-      setAssignedUserIds([(task as any).assigneeId]);
-    } else {
-      setAssignedUserIds([]);
+      if (task.assignedUserIds && task.assignedUserIds.length > 0) {
+        setAssignedUserIds(task.assignedUserIds);
+      } else if ((task as any).assigneeId) {
+        setAssignedUserIds([(task as any).assigneeId]);
+      } else {
+        setAssignedUserIds([]);
+      }
+
+      setTags(normalizeTaskTags(task.tags ?? []));
+      setLocalComments([]);
+      setCommentText("");
+      return;
     }
 
-    setLocalComments([]);
-    setCommentText("");
-  }, [task, open]);
+    if (isCreateMode) {
+      resetForm();
+      setProjectId(defaultProjectId ?? "");
+    }
+  }, [task, open, isEditMode, isCreateMode, resetForm, defaultProjectId]);
 
-  const updateTaskMutation = useMutation({
-    mutationFn: async () => {
-      if (!task) return;
+  useEffect(() => {
+    if (!open) {
+      resetForm();
+    }
+  }, [open, resetForm]);
 
-      const updates = {
+  const buildPayload = useCallback(
+    (overrides: Partial<TaskFormState> = {}): TaskMutationPayload => {
+      const currentState: TaskFormState = {
         title,
         description,
         status,
         priority,
-        projectId: projectId || null,
-        startDate: startDate ? new Date(startDate) : null,
-        dueDate: dueDate ? new Date(dueDate) : null,
+        projectId,
+        startDate,
+        dueDate,
         assignedUserIds,
-        updatedAt: new Date(),
-      } as Partial<Task> & { updatedAt: Date };
+        tags,
+        ...overrides,
+      };
 
-      await firebaseService.updateTask(task.id, updates);
+      const sanitizedTags = normalizeTaskTags(currentState.tags ?? []);
+
+      return {
+        title: currentState.title.trim(),
+        description: currentState.description.trim() ? currentState.description.trim() : null,
+        status: currentState.status,
+        priority: currentState.priority,
+        projectId: currentState.projectId ? currentState.projectId : null,
+        startDate: currentState.startDate ? new Date(currentState.startDate) : null,
+        dueDate: currentState.dueDate ? new Date(currentState.dueDate) : null,
+        assignedUserIds: currentState.assignedUserIds,
+        tags: sanitizedTags,
+      };
+    },
+    [title, description, status, priority, projectId, startDate, dueDate, assignedUserIds, tags]
+  );
+
+  const createTaskMutation = useMutation({
+    mutationFn: async (payload: TaskMutationPayload) => {
+      await firebaseService.createTask({
+        ...payload,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/dashboard/enhanced"] });
+      toast({
+        title: "Tarefa criada",
+        description: "A nova tarefa foi adicionada com sucesso.",
+      });
+      resetForm();
+      onOpenChange(false);
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erro ao criar tarefa",
+        description: error?.message || "Não foi possível criar a tarefa.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateTaskMutation = useMutation({
+    mutationFn: async (payload: TaskMutationPayload) => {
+      if (!task) return;
+
+      await firebaseService.updateTask(task.id, {
+        ...payload,
+        updatedAt: new Date(),
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/tasks"] });
@@ -151,17 +261,48 @@ export function TaskDetailsDrawer({
     },
   });
 
+  const isSubmitting = createTaskMutation.isPending || updateTaskMutation.isPending;
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    if (!task) return;
-    updateTaskMutation.mutate();
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle) {
+      toast({
+        title: "Título obrigatório",
+        description: "Informe um título para a tarefa.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!dueDate) {
+      toast({
+        title: "Data de vencimento obrigatória",
+        description: "Defina uma data de vencimento para a tarefa.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const payload = buildPayload();
+
+    if (isCreateMode) {
+      createTaskMutation.mutate(payload);
+      return;
+    }
+
+    if (isEditMode && task) {
+      updateTaskMutation.mutate(payload);
+    }
   };
 
   const handleMarkAsCompleted = () => {
     if (!task) return;
     const nextStatus = status === "concluida" ? "em_andamento" : "concluida";
     setStatus(nextStatus as Task["status"]);
-    updateTaskMutation.mutate();
+    const payload = buildPayload({ status: nextStatus as Task["status"] });
+    updateTaskMutation.mutate(payload);
   };
 
   const handleToggleUser = (userId: string) => {
@@ -198,6 +339,29 @@ export function TaskDetailsDrawer({
     [users, assignedUserIds]
   );
 
+  const handleAddTag = () => {
+    setTags((prev) => [
+      ...prev,
+      {
+        id: generateTagId(),
+        name: "",
+        color: DEFAULT_TAG_COLOR,
+      },
+    ]);
+  };
+
+  const handleTagNameChange = (id: string, value: string) => {
+    setTags((prev) => prev.map((tag) => (tag.id === id ? { ...tag, name: value } : tag)));
+  };
+
+  const handleTagColorChange = (id: string, value: string) => {
+    setTags((prev) => prev.map((tag) => (tag.id === id ? { ...tag, color: value } : tag)));
+  };
+
+  const handleRemoveTag = (id: string) => {
+    setTags((prev) => prev.filter((tag) => tag.id !== id));
+  };
+
   const activeProjectName = useMemo(() => {
     if (!projectId) return "Sem projeto";
     return projects.find((project) => project.id === projectId)?.name || "Projeto não encontrado";
@@ -218,34 +382,37 @@ export function TaskDetailsDrawer({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      {task ? (
-        <SheetContent
-          side="right"
-          className="w-full sm:max-w-xl lg:max-w-3xl p-0 overflow-hidden"
-        >
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-xl lg:max-w-3xl p-0 overflow-hidden"
+      >
           <div className="flex h-full flex-col bg-background text-foreground">
             <div className="border-b border-border px-6 py-6">
               <SheetHeader className="space-y-3">
                 <SheetTitle className="text-xl font-semibold">
-                  {title || task.title || "Detalhes da tarefa"}
+                  {isCreateMode ? "Criar nova tarefa" : title || task?.title || "Detalhes da tarefa"}
                 </SheetTitle>
                 <SheetDescription className="text-sm text-muted-foreground">
-                  Gerencie os principais detalhes da tarefa selecionada.
+                  {isCreateMode
+                    ? "Preencha as informações para adicionar uma nova tarefa."
+                    : "Gerencie os principais detalhes da tarefa selecionada."}
                 </SheetDescription>
               </SheetHeader>
 
               <div className="mt-4 flex flex-wrap items-center gap-3">
-                <Button
-                  size="sm"
-                  variant={status === "concluida" ? "outline" : "default"}
-                  className="rounded-full px-4"
-                  onClick={handleMarkAsCompleted}
-                  type="button"
-                  disabled={updateTaskMutation.isPending}
-                >
-                  <CheckCircle2 className="mr-2 h-4 w-4" />
-                  {status === "concluida" ? "Marcar como em andamento" : "Marcar como concluída"}
-                </Button>
+                {isEditMode && (
+                  <Button
+                    size="sm"
+                    variant={status === "concluida" ? "outline" : "default"}
+                    className="rounded-full px-4"
+                    onClick={handleMarkAsCompleted}
+                    type="button"
+                    disabled={isSubmitting}
+                  >
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    {status === "concluida" ? "Marcar como em andamento" : "Marcar como concluída"}
+                  </Button>
+                )}
 
                 <Badge className={cn("rounded-full px-3 py-1 text-xs", statusColor)}>
                   {STATUS_LABELS[status] || status}
@@ -295,16 +462,6 @@ export function TaskDetailsDrawer({
                 <section className="space-y-3 rounded-xl border border-border bg-card p-5">
                   <div className="flex items-center justify-between">
                     <h3 className="text-sm font-semibold">Responsáveis & Status</h3>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="rounded-full text-muted-foreground"
-                      type="button"
-                      onClick={() => task && onOpenAdvancedEdit?.(task)}
-                    >
-                      <Edit className="mr-2 h-4 w-4" />
-                      Modo avançado
-                    </Button>
                   </div>
 
                   <div className="grid gap-4 md:grid-cols-2">
@@ -465,76 +622,119 @@ export function TaskDetailsDrawer({
                   </div>
                 </section>
 
-                {(task.tags && task.tags.length > 0) && (
-                  <section className="space-y-3 rounded-xl border border-border bg-card p-5">
+                <section className="space-y-3 rounded-xl border border-border bg-card p-5">
+                  <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 text-sm font-semibold">
                       <TagIcon className="h-4 w-4 text-primary" />
                       Etiquetas
                     </div>
-                    <div className="flex flex-wrap gap-2">
-                      {task.tags.map((tag: TaskTag) => {
+                    <Button type="button" variant="outline" size="sm" onClick={handleAddTag}>
+                      <Plus className="mr-2 h-4 w-4" /> Adicionar etiqueta
+                    </Button>
+                  </div>
+                  {tags.length === 0 ? (
+                    <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-xs text-muted-foreground">
+                      Nenhuma etiqueta adicionada.
+                    </p>
+                  ) : (
+                    <div className="space-y-3">
+                      {tags.map((tag) => {
                         const backgroundColor = tag.color || DEFAULT_TAG_COLOR;
                         const textColor = getTagTextColor(backgroundColor);
                         return (
-                          <Badge
+                          <div
                             key={tag.id}
-                            variant="outline"
-                            className="border-transparent text-xs font-medium"
-                            style={{ backgroundColor, color: textColor }}
+                            className="grid gap-3 rounded-lg border border-border bg-muted/40 p-3 sm:grid-cols-[1fr_auto] sm:items-center"
                           >
-                            {tag.name}
-                          </Badge>
+                            <div className="space-y-2">
+                              <Label className="text-xs font-medium uppercase text-muted-foreground">Nome</Label>
+                              <Input
+                                value={tag.name}
+                                onChange={(event) => handleTagNameChange(tag.id, event.target.value)}
+                                placeholder="Nome da etiqueta"
+                              />
+                            </div>
+                            <div className="flex flex-col gap-2 sm:items-end">
+                              <Label className="text-xs font-medium uppercase text-muted-foreground">Cor</Label>
+                              <div className="flex items-center gap-2">
+                                <input
+                                  type="color"
+                                  value={backgroundColor}
+                                  onChange={(event) => handleTagColorChange(tag.id, event.target.value)}
+                                  className="h-10 w-10 cursor-pointer rounded border border-border bg-background p-1"
+                                />
+                                <Badge
+                                  variant="outline"
+                                  className="border-transparent text-xs"
+                                  style={{ backgroundColor, color: textColor }}
+                                >
+                                  {tag.name || "Pré-visualização"}
+                                </Badge>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  onClick={() => handleRemoveTag(tag.id)}
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            </div>
+                          </div>
                         );
                       })}
                     </div>
+                  )}
+                </section>
+
+                {isEditMode && (
+                  <section className="space-y-3 rounded-xl border border-border bg-card p-5">
+                    <h3 className="text-sm font-semibold">Comentários rápidos</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Registre alinhamentos ou decisões importantes. Os comentários são salvos localmente por enquanto.
+                    </p>
+                    <Textarea
+                      value={commentText}
+                      onChange={(event) => setCommentText(event.target.value)}
+                      placeholder="Escreva um comentário ou atualize o andamento da tarefa..."
+                      rows={3}
+                    />
+                    <div className="flex items-center justify-between">
+                      <Button type="button" size="sm" onClick={handleAddComment}>
+                        Adicionar comentário
+                      </Button>
+                      {onDelete && task && (
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="icon"
+                          onClick={() => onDelete(task)}
+                          disabled={isSubmitting}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="space-y-3">
+                      {localComments.length === 0 ? (
+                        <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-xs text-muted-foreground">
+                          Nenhum comentário adicionado ainda.
+                        </p>
+                      ) : (
+                        localComments.map((comment) => (
+                          <div key={comment.id} className="rounded-xl border border-border bg-muted/60 p-3 text-sm text-foreground">
+                            <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+                              <span>Você</span>
+                              <span>{format(comment.createdAt, "dd/MM/yyyy HH:mm")}</span>
+                            </div>
+                            <p>{comment.text}</p>
+                          </div>
+                        ))
+                      )}
+                    </div>
                   </section>
                 )}
-
-                <section className="space-y-3 rounded-xl border border-border bg-card p-5">
-                  <h3 className="text-sm font-semibold">Comentários rápidos</h3>
-                  <p className="text-xs text-muted-foreground">
-                    Registre alinhamentos ou decisões importantes. Os comentários são salvos localmente por enquanto.
-                  </p>
-                  <Textarea
-                    value={commentText}
-                    onChange={(event) => setCommentText(event.target.value)}
-                    placeholder="Escreva um comentário ou atualize o andamento da tarefa..."
-                    rows={3}
-                  />
-                  <div className="flex items-center justify-between">
-                    <Button type="button" size="sm" onClick={handleAddComment}>
-                      Adicionar comentário
-                    </Button>
-                    {onDelete && (
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        size="icon"
-                        onClick={() => task && onDelete(task)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
-
-                  <div className="space-y-3">
-                    {localComments.length === 0 ? (
-                      <p className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-xs text-muted-foreground">
-                        Nenhum comentário adicionado ainda.
-                      </p>
-                    ) : (
-                      localComments.map((comment) => (
-                        <div key={comment.id} className="rounded-xl border border-border bg-muted/60 p-3 text-sm text-foreground">
-                          <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
-                            <span>Você</span>
-                            <span>{format(comment.createdAt, "dd/MM/yyyy HH:mm")}</span>
-                          </div>
-                          <p>{comment.text}</p>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                </section>
               </div>
 
               <div className="border-t border-border bg-muted/30 px-6 py-4">
@@ -548,23 +748,28 @@ export function TaskDetailsDrawer({
                       variant="ghost"
                       className="text-muted-foreground"
                       onClick={() => onOpenChange(false)}
-                      disabled={updateTaskMutation.isPending}
+                      disabled={isSubmitting}
                     >
                       Cancelar
                     </Button>
                     <Button
                       type="submit"
-                      disabled={updateTaskMutation.isPending}
+                      disabled={isSubmitting}
                     >
-                      {updateTaskMutation.isPending ? "Salvando..." : "Salvar alterações"}
+                      {isCreateMode
+                        ? isSubmitting
+                          ? "Criando..."
+                          : "Criar tarefa"
+                        : updateTaskMutation.isPending
+                          ? "Salvando..."
+                          : "Salvar alterações"}
                     </Button>
                   </div>
                 </div>
               </div>
             </form>
           </div>
-        </SheetContent>
-      ) : null}
+      </SheetContent>
     </Sheet>
   );
 }


### PR DESCRIPTION
## Summary
- expand the task details drawer to support creating tasks, inline tag management, and submission handling without the advanced modal
- update both Kanban board variants to open the drawer for task creation and editing, removing the old TaskModal usage
- adjust task card components to interoperate with the drawer and clean up typing around metadata

## Testing
- npm run check *(fails: existing TypeScript issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68df27b89e80832288f519ecebd009c1